### PR TITLE
chore: run lint after tests so peer dependencies are installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build
-    - run: npm run lint
     - run: npm test
+    - run: npm run lint


### PR DESCRIPTION
Lint needs to run after tests, as this library is being tested with both express 4 and express 5, which are installed during the test step.